### PR TITLE
Add verbose support

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,7 @@
 # CHANGELOG
 
+- [#??] Added support for `--verbose`/`-v` to `get:status`
+
 ### 0.6.0
 
 - [#17] Added `get:release-line` command

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,6 @@
 # CHANGELOG
 
-- [#??] Added support for `--verbose`/`-v` to `get:status`
+- [#21] Added support for `--verbose`/`-v` to `get:status`
 
 ### 0.6.0
 
@@ -33,3 +33,4 @@
 [#14]: https://github.com/warehouseai/wrhs/pull/14
 [#16]: https://github.com/warehouseai/wrhs/pull/16
 [#17]: https://github.com/warehouseai/wrhs/pull/17
+[#21]: https://github.com/warehouseai/wrhs/pull/21

--- a/README.md
+++ b/README.md
@@ -32,7 +32,7 @@ $ npm install -g wrhs
 $ wrhs COMMAND
 running command...
 $ wrhs (-v|--version|version)
-wrhs/0.6.0 darwin-x64 node-v10.15.0
+wrhs/0.6.0 darwin-x64 node-v10.16.2
 $ wrhs --help [COMMAND]
 USAGE
   $ wrhs COMMAND
@@ -190,6 +190,9 @@ OPTIONS
   -p, --pass=pass                Password
   -s, --status-host=status-host  The base url for the warehouse status API
   -u, --user=user                Username
+
+  -v, --verbose                  Should status events be more verbose. Events will print out their details property.
+                                 Defaults to false
 
 DESCRIPTION
   -e can be used to get the more granular status events.

--- a/src/commands/get/status.js
+++ b/src/commands/get/status.js
@@ -69,8 +69,9 @@ class StatusCommand extends Command {
    * @param {Number} progress.count - Number of completed builds
    * @param {Number} progress.total - Total number of builds
    * @param {string} locale - A locale to filter events by
+   * @param {bool} verbose - Whether to display verbose data
    */
-  renderEvents(events, progress, locale) {
+  renderEvents(events, progress, locale, verbose) {
     const firstStatus = events[0];
     this.renderHeader(firstStatus, !events.every(event => !event.error), progress.progress === 100, progress);
 
@@ -82,8 +83,13 @@ class StatusCommand extends Command {
       let eventlocale = event.locale ? chalk.cyan(event.locale) : '';
       eventlocale += new Array(7 - localeLen).join(' ');
       const createDate = event.createDate || event.createdAt;
+      const verboseDetails = verbose ? 
+        `\n\t${chalk.yellow('Details')}: ${ event.details || '[None]' }` :
+        ''
 
-      this.log(`${chalk[chalkColor](createDate)} ${eventlocale}: `, event.message);
+      this.log(`${chalk[chalkColor](createDate)} ${eventlocale}: `,
+        event.message,
+        verboseDetails);
     });
 
     this.log('');
@@ -121,7 +127,7 @@ class StatusCommand extends Command {
       const progress = await thenify(wrhs.status, 'progress', { pkg, env: args.env, version });
 
       if (flags.events) {
-        return this.renderEvents(response, progress, flags.locale);
+        return this.renderEvents(response, progress, flags.locale, flags.verbose);
       }
 
       this.render(response, progress, args);
@@ -150,6 +156,11 @@ StatusCommand.flags = {
   events: flagUtils.boolean({
     char: 'e',
     description: 'Should status events be fetched. Defaults to false'
+  }),
+  verbose: flagUtils.boolean({
+    char: 'v',
+    description: 'Should status events be more verbose. Events will print out their details property. Defaults to false',
+    dependsOn: ['events']
   }),
   locale: flagUtils.string({
     char: 'l',

--- a/test/commands/getCommands/status.test.js
+++ b/test/commands/getCommands/status.test.js
@@ -165,6 +165,22 @@ describe('get:status', () => {
       assume(ctx.stdout).contains('2018-07-11T00:33:00.000Z de    :  built de thing');
     });
 
+  // Verbose Output
+  test
+    .nock('https://warehouse-status.ai', generateMockWarehouseRoute({
+      path: '/status-events/%40scope%2Fpackage/env/version',
+      fixture: statusEventFixture
+    }))
+    .stdout()
+    .command(['get:status', '@scope/package@version', 'env', '-e', '-v'])
+    .it('can fetch status event information for a given version', ctx => {
+      validateStatusEvent(ctx);
+      assume(ctx.stdout).contains('Details: a thing was built');
+      assume(ctx.stdout).contains('Details: another thing was built');
+      assume(ctx.stdout).contains('Details: [None]');
+    });
+
+
   // No status host
   test
     .do(function () {


### PR DESCRIPTION

## Summary

When debugging build failures, the data to debug it is there in status events, but isn't available from this CLI.  This adds `-v` to `get:status` so users can see their build failures.
## Changelog

- Added support for `--verbose`/`-v` to `get:status`

## Test Plan

Added tests to show `details` field being written
