### PR TITLE
[feat] Add support for --config flag

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,7 +1,7 @@
 language: node_js
 node_js:
-  - "8"
   - "10"
+  - "12"
 
 matrix:
   fast_finish: true

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,7 @@
 # CHANGELOG
 
+- [#22] Added support for `--config`
+
 ### 0.7.0
 
 - [#21] Added support for `--verbose`/`-v` to `get:status`
@@ -36,3 +38,4 @@
 [#16]: https://github.com/warehouseai/wrhs/pull/16
 [#17]: https://github.com/warehouseai/wrhs/pull/17
 [#21]: https://github.com/warehouseai/wrhs/pull/21
+[#22]: https://github.com/warehouseai/wrhs/pull/22

--- a/README.md
+++ b/README.md
@@ -32,7 +32,7 @@ $ npm install -g wrhs
 $ wrhs COMMAND
 running command...
 $ wrhs (-v|--version|version)
-wrhs/0.7.0 darwin-x64 node-v10.16.0
+wrhs/0.7.0 darwin-x64 node-v10.16.2
 $ wrhs --help [COMMAND]
 USAGE
   $ wrhs COMMAND
@@ -85,6 +85,7 @@ ARGUMENTS
   ENV      The environment to build in
 
 OPTIONS
+  -c, --config=config            The file location of the warehouse config, defaults to `~/.wrhs`
   -h, --host=host                The base url for the warehouse API
   -j, --json                     Output response data as JSON
   -m, --promote                  Should promotion happen on successful build. Defaults to false
@@ -112,6 +113,7 @@ ARGUMENTS
   LOCALE   The specific locale to fetch. Defaults to en-US
 
 OPTIONS
+  -c, --config=config            The file location of the warehouse config, defaults to `~/.wrhs`
   -h, --host=host                The base url for the warehouse API
   -j, --json                     Output response data as JSON
   -p, --pass=pass                Password
@@ -137,6 +139,7 @@ ARGUMENTS
   ENV      The environment to get the head build for
 
 OPTIONS
+  -c, --config=config            The file location of the warehouse config, defaults to `~/.wrhs`
   -h, --host=host                The base url for the warehouse API
   -j, --json                     Output response data as JSON
   -p, --pass=pass                Password
@@ -161,6 +164,7 @@ ARGUMENTS
   PACKAGE  The package and version (optional) to get the release line for (example: `pkg@1.2.3`)
 
 OPTIONS
+  -c, --config=config            The file location of the warehouse config, defaults to `~/.wrhs`
   -h, --host=host                The base url for the warehouse API
   -j, --json                     Output response data as JSON
   -p, --pass=pass                Password
@@ -183,6 +187,7 @@ ARGUMENTS
   ENV      The environment to get status information for
 
 OPTIONS
+  -c, --config=config            The file location of the warehouse config, defaults to `~/.wrhs`
   -e, --events                   Should status events be fetched. Defaults to false
   -h, --host=host                The base url for the warehouse API
   -j, --json                     Output response data as JSON
@@ -234,6 +239,7 @@ ARGUMENTS
 
 OPTIONS
   -b, --build                    Should build the package before promoting. Defaults to false
+  -c, --config=config            The file location of the warehouse config, defaults to `~/.wrhs`
   -h, --host=host                The base url for the warehouse API
   -j, --json                     Output response data as JSON
   -p, --pass=pass                Password

--- a/package-lock.json
+++ b/package-lock.json
@@ -447,6 +447,12 @@
         "pruddy-error": "^2.0.2"
       }
     },
+    "assume-sinon": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/assume-sinon/-/assume-sinon-1.0.1.tgz",
+      "integrity": "sha512-6+87n91l01YWYYUvlFupZkoXueVPVUEw6QY3My0vr8wgTb7VZ9bCVIa9E8MiVphBfqHXGTC5DP+hto7x5W+mPA==",
+      "dev": true
+    },
     "astral-regex": {
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/astral-regex/-/astral-regex-1.0.0.tgz",
@@ -4264,6 +4270,11 @@
       "version": "0.1.2",
       "resolved": "https://registry.npmjs.org/universalify/-/universalify-0.1.2.tgz",
       "integrity": "sha512-rBJeI5CXAlmy1pV+617WB9J63U6XcazHHF2f2dbJix4XzpUF0RS3Zbj0FGIOCAva5P/d/GBOYaACQ1w+0azUkg=="
+    },
+    "untildify": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/untildify/-/untildify-4.0.0.tgz",
+      "integrity": "sha512-KK8xQ1mkzZeg9inewmFVDNkg3l5LUhoq9kN6iWYB/CC9YMG8HA+c1Q8HwDe6dEX7kErrEVNVBO3fWsVq5iDgtw=="
     },
     "uri-js": {
       "version": "4.2.2",

--- a/package.json
+++ b/package.json
@@ -10,8 +10,8 @@
     "lint": "eslint-godaddy src/*.js src/**/*.js test/*.js test/**/*.js",
     "postpack": "rm -f oclif.manifest.json npm-shrinkwrap.json",
     "prepack": "oclif-dev manifest && oclif-dev readme && npm shrinkwrap",
-    "pretest": "npm run lint",
-    "test": "nyc mocha --forbid-only \"test/**/*.test.js\"",
+    "posttest": "npm run lint",
+    "test": "nyc mocha \"test/**/*.test.js\"",
     "test:mocha": "TEST_OUTPUT=1 nyc mocha 'test/**/*.test.js'",
     "version": "oclif-dev readme && git add README.md"
   },
@@ -57,12 +57,14 @@
     "debug": "^4.1.1",
     "terminal-link": "^1.3.0",
     "tinythen": "^1.0.1",
+    "untildify": "^4.0.0",
     "warehouse.ai-api-client": "^4.4.0"
   },
   "devDependencies": {
     "@oclif/dev-cli": "^1.22.0",
     "@oclif/test": "^1.2.4",
     "assume": "^2.2.0",
+    "assume-sinon": "^1.0.1",
     "chai": "^4.1.2",
     "eslint": "^5.16.0",
     "eslint-config-godaddy": "^3.0.0",

--- a/test/commands/getCommands/build.test.js
+++ b/test/commands/getCommands/build.test.js
@@ -4,6 +4,7 @@ const buildFixture = require('../../fixtures/build');
 const fs = require('fs');
 const sinon = require('sinon');
 const assume = require('assume');
+assume.use(require('assume-sinon'));
 
 const mockConfig = {
   host: 'warehouse.ai',

--- a/test/commands/getCommands/build.test.js
+++ b/test/commands/getCommands/build.test.js
@@ -1,3 +1,4 @@
+/* eslint no-sync: 0 */
 const { test } = require('@oclif/test');
 const buildFixture = require('../../fixtures/build');
 const fs = require('fs');
@@ -59,15 +60,15 @@ const validate = ({ stdout }) => {
 };
 
 describe('get:build', function () {
-  before(function () {
+  beforeEach(function () {
     sinon.stub(fs, 'readFileSync')
       .withArgs(sinon.match('.wrhs'), 'utf8')
       .returns(JSON.stringify(mockConfig));
 
-    fs.readFileSync.callThrough(); // eslint-disable-line no-sync
+    fs.readFileSync.callThrough();
   });
 
-  after(function () {
+  afterEach(function () {
     sinon.restore();
   });
 
@@ -124,7 +125,7 @@ describe('get:build', function () {
   // Host fallback
   test
     .do(function () {
-      fs.readFileSync // eslint-disable-line no-sync
+      fs.readFileSync
         .withArgs(sinon.match('.wrhs'), 'utf8')
         .returns(JSON.stringify({
           host: 'wrhs-host.ai',
@@ -138,10 +139,11 @@ describe('get:build', function () {
     .stdout()
     .command(['get:build', 'package', 'dev'])
     .it('fallsback to the `host` config', validate);
+
   // No host
   test
     .do(function () {
-      fs.readFileSync // eslint-disable-line no-sync
+      fs.readFileSync
         .withArgs(sinon.match('.wrhs'), 'utf8')
         .returns(JSON.stringify({
           auth: {
@@ -154,7 +156,30 @@ describe('get:build', function () {
     .command(['get:build', 'package', 'env'])
     .catch(err => {
       assume(err.oclif.exit).equals(2);
-      assume(err.message).contains('Missing warehouse host. Please configure a `~/.wrhs` config file or use the `--host` option.');
+      assume(err.message).contains('Missing warehouse host. Please configure a `~/.wrhs` config file, use the `--config` option, or use the `--host` option.');
     })
     .it('Outputs an error if there is no wrhs host');
+
+
+  // Different Host File
+  test
+    .do(function () {
+      fs.readFileSync
+        .withArgs(sinon.match('.foo-bar'), 'utf8')
+        .returns(JSON.stringify({
+          host: 'wrhs-host.ai',
+          auth: {
+            user: 'user',
+            pass: 'pass'
+          }
+        }));
+    })
+    .nock('https://wrhs-host.ai', generateMockWarehouseRoute())
+    .stdout()
+    .command(['get:build', 'package', 'dev', '--config', '~/.foo-bar'])
+    .it('can override wrhs config file', function () {
+      assume(fs.readFileSync).was.calledWith(sinon.match('.foo-bar'), 'utf8');
+      assume(fs.readFileSync).was.not.calledWith(sinon.match('.wrhs'), 'utf8');
+      validate(...arguments);
+    });
 });

--- a/test/commands/getCommands/head.test.js
+++ b/test/commands/getCommands/head.test.js
@@ -1,3 +1,4 @@
+/* eslint no-sync: 0 */
 const { test } = require('@oclif/test');
 const responseFixture = require('../../fixtures/head');
 const fs = require('fs');
@@ -79,15 +80,15 @@ const validate = ({ stdout }) => {
 };
 
 describe('get:head', () => {
-  before(function () {
+  beforeEach(function () {
     sinon.stub(fs, 'readFileSync')
       .withArgs(sinon.match('.wrhs'), 'utf8')
       .returns(JSON.stringify(mockConfig));
 
-    fs.readFileSync.callThrough(); // eslint-disable-line no-sync
+    fs.readFileSync.callThrough();
   });
 
-  after(function () {
+  afterEach(function () {
     sinon.restore();
   });
 
@@ -124,7 +125,7 @@ describe('get:head', () => {
   // Host fallback
   test
     .do(function () {
-      fs.readFileSync // eslint-disable-line no-sync
+      fs.readFileSync
         .withArgs(sinon.match('.wrhs'), 'utf8')
         .returns(JSON.stringify({
           host: 'wrhs-host.ai',
@@ -144,7 +145,7 @@ describe('get:head', () => {
   // No host
   test
     .do(function () {
-      fs.readFileSync // eslint-disable-line no-sync
+      fs.readFileSync
         .withArgs(sinon.match('.wrhs'), 'utf8')
         .returns(JSON.stringify({
           auth: {
@@ -157,7 +158,32 @@ describe('get:head', () => {
     .command(['get:build', 'package', 'env'])
     .catch(err => {
       assume(err.oclif.exit).equals(2);
-      assume(err.message).contains('Missing warehouse host. Please configure a `~/.wrhs` config file or use the `--host` option.');
+      assume(err.message).contains('Missing warehouse host. Please configure a `~/.wrhs` config file, use the `--config` option, or use the `--host` option.');
     })
     .it('Outputs an error if there is no wrhs host');
+
+
+  // Different Host File
+  test
+    .do(function () {
+      fs.readFileSync
+        .withArgs(sinon.match('.foo-bar'), 'utf8')
+        .returns(JSON.stringify({
+          host: 'wrhs-host.ai',
+          auth: {
+            user: 'user',
+            pass: 'pass'
+          }
+        }));
+    })
+    .nock('https://wrhs-host.ai', generateMockWarehouseRoute({
+      query: { name: '@scope/package', env: 'dev' }
+    }))
+    .stdout()
+    .command(['get:head', '@scope/package', 'dev', '--config', '~/.foo-bar'])
+    .it('can override wrhs config file', function () {
+      assume(fs.readFileSync).was.calledWith(sinon.match('.foo-bar'), 'utf8');
+      assume(fs.readFileSync).was.not.calledWith(sinon.match('.wrhs'), 'utf8');
+      validate(...arguments);
+    });
 });

--- a/test/commands/getCommands/head.test.js
+++ b/test/commands/getCommands/head.test.js
@@ -4,6 +4,7 @@ const responseFixture = require('../../fixtures/head');
 const fs = require('fs');
 const sinon = require('sinon');
 const assume = require('assume');
+assume.use(require('assume-sinon'));
 
 const mockConfig = {
   host: 'warehouse.ai',

--- a/test/commands/getCommands/release-line.test.js
+++ b/test/commands/getCommands/release-line.test.js
@@ -4,6 +4,7 @@ const releaseLineFixture = require('../../fixtures/release-line');
 const fs = require('fs');
 const sinon = require('sinon');
 const assume = require('assume');
+assume.use(require('assume-sinon'));
 
 const mockConfig = {
   host: 'warehouse.ai',

--- a/test/commands/getCommands/release-line.test.js
+++ b/test/commands/getCommands/release-line.test.js
@@ -1,3 +1,4 @@
+/* eslint no-sync: 0 */
 const { test } = require('@oclif/test');
 const releaseLineFixture = require('../../fixtures/release-line');
 const fs = require('fs');
@@ -37,15 +38,15 @@ const validate = ({ stdout }) => {
 };
 
 describe('get:release-line', function () {
-  before(function () {
+  beforeEach(function () {
     sinon.stub(fs, 'readFileSync')
       .withArgs(sinon.match('.wrhs'), 'utf8')
       .returns(JSON.stringify(mockConfig));
 
-    fs.readFileSync.callThrough(); // eslint-disable-line no-sync
+    fs.readFileSync.callThrough();
   });
 
-  after(function () {
+  afterEach(function () {
     sinon.restore();
   });
 
@@ -91,7 +92,7 @@ describe('get:release-line', function () {
   // Host fallback
   test
     .do(function () {
-      fs.readFileSync // eslint-disable-line no-sync
+      fs.readFileSync
         .withArgs(sinon.match('.wrhs'), 'utf8')
         .returns(JSON.stringify({
           host: 'wrhs-host.ai',
@@ -109,7 +110,7 @@ describe('get:release-line', function () {
   // No host
   test
     .do(function () {
-      fs.readFileSync // eslint-disable-line no-sync
+      fs.readFileSync
         .withArgs(sinon.match('.wrhs'), 'utf8')
         .returns(JSON.stringify({
           auth: {
@@ -122,7 +123,30 @@ describe('get:release-line', function () {
     .command(['get:release-line', 'package@1.0.0'])
     .catch(err => {
       assume(err.oclif.exit).equals(2);
-      assume(err.message).contains('Missing warehouse host. Please configure a `~/.wrhs` config file or use the `--host` option.');
+      assume(err.message).contains('Missing warehouse host. Please configure a `~/.wrhs` config file, use the `--config` option, or use the `--host` option.');
     })
     .it('Outputs an error if there is no wrhs host');
+
+
+  // Different Host File
+  test
+    .do(function () {
+      fs.readFileSync
+        .withArgs(sinon.match('.foo-bar'), 'utf8')
+        .returns(JSON.stringify({
+          host: 'wrhs-host.ai',
+          auth: {
+            user: 'user',
+            pass: 'pass'
+          }
+        }));
+    })
+    .nock('https://wrhs-host.ai', generateMockWarehouseRoute())
+    .stdout()
+    .command(['get:release-line', 'package@1.0.0', '--config', '~/.foo-bar'])
+    .it('can override wrhs config file', function () {
+      assume(fs.readFileSync).was.calledWith(sinon.match('.foo-bar'), 'utf8');
+      assume(fs.readFileSync).was.not.calledWith(sinon.match('.wrhs'), 'utf8');
+      validate(...arguments);
+    });
 });

--- a/test/commands/getCommands/status.test.js
+++ b/test/commands/getCommands/status.test.js
@@ -8,6 +8,7 @@ const {
   statusError: statusErrorFixture,
   statusEvent: statusEventFixture
 } = require('../../fixtures/status');
+assume.use(require('assume-sinon'));
 
 const mockConfig = {
   hosts: {

--- a/test/commands/promote.test.js
+++ b/test/commands/promote.test.js
@@ -3,6 +3,7 @@ const { test } = require('@oclif/test');
 const fs = require('fs');
 const sinon = require('sinon');
 const assume = require('assume');
+assume.use(require('assume-sinon'));
 
 const mockConfig = {
   host: 'warehouse.ai',

--- a/test/commands/promote.test.js
+++ b/test/commands/promote.test.js
@@ -1,3 +1,4 @@
+/* eslint no-sync: 0 */
 const { test } = require('@oclif/test');
 const fs = require('fs');
 const sinon = require('sinon');
@@ -37,15 +38,15 @@ const validateWithBuild = ({ stdout }) => {
 };
 
 describe('promote', function () {
-  before(function () {
+  beforeEach(function () {
     sinon.stub(fs, 'readFileSync')
       .withArgs(sinon.match('.wrhs'), 'utf8')
       .returns(JSON.stringify(mockConfig));
 
-    fs.readFileSync.callThrough(); // eslint-disable-line no-sync
+    fs.readFileSync.callThrough();
   });
 
-  after(function () {
+  afterEach(function () {
     sinon.restore();
   });
 
@@ -103,7 +104,7 @@ describe('promote', function () {
   // Host fallback
   test
     .do(function () {
-      fs.readFileSync // eslint-disable-line no-sync
+      fs.readFileSync
         .withArgs(sinon.match('.wrhs'), 'utf8')
         .returns(JSON.stringify({
           host: 'wrhs-host-fallback.ai',
@@ -117,4 +118,27 @@ describe('promote', function () {
     .stdout()
     .command(['promote', 'package@version', 'dev'])
     .it('fallsback to the `host` config', validate);
+
+
+  // Different Host File
+  test
+    .do(function () {
+      fs.readFileSync
+        .withArgs(sinon.match('.foo-bar'), 'utf8')
+        .returns(JSON.stringify({
+          host: 'wrhs-host-fallback.ai',
+          auth: {
+            user: 'user',
+            pass: 'pass'
+          }
+        }));
+    })
+    .nock('https://wrhs-host-fallback.ai', generateMockWarehouseRoute())
+    .stdout()
+    .command(['promote', 'package@version', 'dev', '--config', '~/.foo-bar'])
+    .it('can override wrhs config file', function () {
+      assume(fs.readFileSync).was.calledWith(sinon.match('.foo-bar'), 'utf8');
+      assume(fs.readFileSync).was.not.calledWith(sinon.match('.wrhs'), 'utf8');
+      validate(...arguments);
+    });
 });


### PR DESCRIPTION
## Summary

Sometimes you need to work with multiple different warehouse.ai environments (e.g. TEST & PROD).  Having a default config `~/.wrhs` is nice but this provides a way to override with a whole file e.g. `~/.wrhs-test` to easily swap between environments.

## Changelog

> Added support for `--config`

## Test Plan

Updated tests and added new ones for each command.
